### PR TITLE
fix: exfil script calling non-callable error while checking storage exist

### DIFF
--- a/apps/Scripts/Windows_Exfil-GSHD.js
+++ b/apps/Scripts/Windows_Exfil-GSHD.js
@@ -17,7 +17,7 @@ let usbdisk = require("usbdisk");
 let storage = require("storage");
 
 print("Checking for Image...");
-if (storage.exists(image)) {
+if (storage.fileExists(image)) {
     print ("Storage Exists.");
 }
 else {


### PR DESCRIPTION
Fixed the script error by using `storage.fileExists` instead of `storage.exists`